### PR TITLE
Do not verify merges to the main branch

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,20 +29,16 @@ jobs:
       - name: Terraform Format
         id: fmt
         run: terraform fmt -check
-        working-directory: ./terraform
       - name: Terraform Init
         id: init
         run: terraform init
-        working-directory: ./terraform
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
-        working-directory: ./terraform
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
         run: terraform plan -no-color
-        working-directory: ./terraform
         continue-on-error: true
       - name: Update Pull Request
         uses: actions/github-script@0.9.0

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - development
-      - main
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because we already run verification on the development branch and it is required to be up to date before merging, there is no need to run verification again when merging into the main branch.